### PR TITLE
Fix package name in constants; fixes #28

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -30,7 +30,7 @@
  */
 function plugin_useditemsexport_install() {
 
-   $migration = new Migration(PLUGIN_USEDITEMEXPORT_VERSION);
+   $migration = new Migration(PLUGIN_USEDITEMSEXPORT_VERSION);
 
    // Parse inc directory
    foreach (glob(dirname(__FILE__).'/inc/*') as $filepath) {

--- a/setup.php
+++ b/setup.php
@@ -24,11 +24,12 @@
  */
 
 // Plugin version
-define("PLUGIN_USEDITEMEXPORT_VERSION", "2.0.0");
+define("PLUGIN_USEDITEMSEXPORT_VERSION", "2.0.0");
+
 // Minimal GLPI version, inclusive
-define("PLUGIN_USEDITEMEXPORT_MIN_GLPI", "9.2");
+define("PLUGIN_USEDITEMSEXPORT_MIN_GLPI", "9.2");
 // Maximum GLPI version, exclusive
-define("PLUGIN_USEDITEMEXPORT_MAX_GLPI", "9.3");
+define("PLUGIN_USEDITEMSEXPORT_MAX_GLPI", "9.3");
 
 /**
  * Init hooks of the plugin.
@@ -80,15 +81,15 @@ function plugin_version_useditemsexport() {
 
    return  [
       'name' => __('Used items export', 'useditemsexport'),
-      'version' => PLUGIN_USEDITEMEXPORT_VERSION,
+      'version' => PLUGIN_USEDITEMSEXPORT_VERSION,
       'oldname' => '',
       'license' => 'GPLv2+',
       'author'  => "TECLIB",
       'homepage'=>'https://github.com/pluginsGLPI/useditemsexport',
       'requirements'   => [
          'glpi' => [
-            'min' => PLUGIN_USEDITEMEXPORT_MIN_GLPI,
-            'max' => PLUGIN_USEDITEMEXPORT_MAX_GLPI,
+            'min' => PLUGIN_USEDITEMSEXPORT_MIN_GLPI,
+            'max' => PLUGIN_USEDITEMSEXPORT_MAX_GLPI,
             'dev' => true
          ]
       ]


### PR DESCRIPTION
### Changes description

Plugin release tool guess plugin name from `PLUGIN_XXX_VERSION` version constant (see https://github.com/glpi-project/tools/blob/master/tools/plugin-release#L480).
I fixed constant name to fix package generation.

### References

Close: #28 