### PR TITLE
fix: load logo as base64 img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [unrelease] -
+
+### Fixed
+
+- Prevent logo display issue.

--- a/inc/export.class.php
+++ b/inc/export.class.php
@@ -250,7 +250,7 @@ class PluginUseditemsexportExport extends CommonDBTM
         $Author->getFromDB(Session::getLoginUserID());
 
        // Logo
-        $logo = GLPI_PLUGIN_DOC_DIR . '/useditemsexport/logo.png';
+        $logo_base64 = base64_encode(file_get_contents(GLPI_PLUGIN_DOC_DIR . '/useditemsexport/logo.png'));
 
         ob_start();
         ?>
@@ -261,7 +261,7 @@ class PluginUseditemsexportExport extends CommonDBTM
          <page_header>
             <table>
                <tr>
-                  <td style="height: 60mm; width: 40%; text-align: center"><img src="<?php echo $logo; ?>" /></td>
+                  <td style="height: 60mm; width: 40%; text-align: center"><img src="data:image/png;base64,<?php echo $logo_base64; ?>" /></td>
                   <td style="width: 60%; text-align: center;">
                   <?php echo $entity_address; ?>
                   </td>


### PR DESCRIPTION
Since "GLPI_PLUGIN_DOC_DIR" is not accessible from the WEB, the logo was no longer displayed.

I suggest adding it directly in base64 in the img (and it works as a result).