### PR TITLE
Fix Export-GLPIPDF.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.6.2] - 2026-02-02
+
+### Fixed
+
+- Fix error with wrong initialization of `total_count`
+
 ## [2.6.1] - 2025-12-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.6.2] - 2026-02-02
+## [UNRELEASED]
 
 ### Fixed
 

--- a/inc/export.class.php
+++ b/inc/export.class.php
@@ -228,7 +228,7 @@ class PluginUseditemsexportExport extends CommonDBTM
                 $items_for_twig[] = [
                     'serial'      => $item_datas['serial'] ?? '',
                     'otherserial' => $item_datas['otherserial'] ?? '',
-                    'name'        => $item_datas['name'],
+                    'name'        => $item_datas['name'] ?? '',
                     'type'        => $item_obj->getTypeName(1),
                 ];
             }
@@ -251,8 +251,8 @@ class PluginUseditemsexportExport extends CommonDBTM
             'orientation' => $useditemsexport_config['orientation'],
             'format'      => $useditemsexport_config['format'],
         ]);
-        $pdf->WriteHTML($content);
         $pdf->setTotalCount($total_count);
+        $pdf->WriteHTML($content);
         $contentPDF = $pdf->Output('', 'S');
 
         file_put_contents(GLPI_UPLOAD_DIR . '/' . $refnumber . '.pdf', $contentPDF);


### PR DESCRIPTION
## Checklist before requesting a review


- [X] I have performed a self-review of my code.

## Description
Correction of : 

glpi.CRITICAL:   *** Uncaught PHP Exception Error: "Typed property GLPIPDF::$total_count must not be accessed before initialization" at GLPIPDF.php line 136
  Backtrace :
  ./src/GLPIPDF.php:136                              
  ./vendor/tecnickcom/tcpdf/tcpdf.php:3678           GLPIPDF->Footer()
  ./vendor/tecnickcom/tcpdf/tcpdf.php:3224           TCPDF->setFooter()
  ./vendor/tecnickcom/tcpdf/tcpdf.php:3206           TCPDF->endPage()
  ./vendor/tecnickcom/tcpdf/tcpdf.php:5098           TCPDF->AddPage()
  ./vendor/tecnickcom/tcpdf/tcpdf.php:18218          TCPDF->checkPageBreak()
  ...tplace/useditemsexport/inc/export.class.php:254 TCPDF->writeHTML()
  ...tplace/useditemsexport/front/export.form.php:40 PluginUseditemsexportExport::generatePDF()
  ...Glpi/Controller/LegacyFileLoadController.php:64 require()
  ./vendor/symfony/http-kernel/HttpKernel.php:181    Glpi\Controller\LegacyFileLoadController->__invoke()
  ./vendor/symfony/http-kernel/HttpKernel.php:76     Symfony\Component\HttpKernel\HttpKernel->handleRaw()
  ./vendor/symfony/http-kernel/Kernel.php:197        Symfony\Component\HttpKernel\HttpKernel->handle()
  ./public/index.php:70                              Symfony\Component\HttpKernel\Kernel->handle()

GLPI Version : 11.0.4