### PR TITLE
Fix: check entity access before purging export records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix missing entity check when purging an export record
+
 ## [2.6.2] - 2026-05-12
 
 ### Fixed

--- a/front/export.form.php
+++ b/front/export.form.php
@@ -31,12 +31,18 @@
 
 include(__DIR__ . '/../../../inc/includes.php');
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
+
 Session::checkLoginUser();
 
 $PluginUseditemsexportExport = new PluginUseditemsexportExport();
 
 if (isset($_REQUEST['generate'])) {
     Session::checkRight('plugin_useditemsexport_export', CREATE);
+    $User = new User();
+    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToEntity($User->getEntityID())) {
+        throw new AccessDeniedHttpException();
+    }
     if ($PluginUseditemsexportExport::generatePDF($_POST['users_id'])) {
         Session::addMessageAfterRedirect(__s('PDF successfully generated.', 'useditemsexport'), true);
         Html::back();
@@ -46,9 +52,9 @@ if (isset($_REQUEST['generate'])) {
 if (isset($_REQUEST['purgeitem'])) {
     Session::checkRight('plugin_useditemsexport_export', PURGE);
     foreach ($_POST['useditemsexport'] as $key => $val) {
-        $input = ['id' => $key];
         if ($val == 1) {
-            $PluginUseditemsexportExport->delete($input, true);
+            $PluginUseditemsexportExport->check($key, PURGE);
+            $PluginUseditemsexportExport->delete(['id' => $key], true);
         }
     }
     Html::back();

--- a/hook.php
+++ b/hook.php
@@ -53,6 +53,7 @@ function plugin_useditemsexport_install()
             }
         }
     }
+    $migration->executeMigration();
     return true;
 }
 

--- a/inc/export.class.php
+++ b/inc/export.class.php
@@ -477,9 +477,12 @@ class PluginUseditemsexportExport extends CommonDBTM
             $migration->addField($table, 'entities_id', "INT {$default_key_sign} NOT NULL DEFAULT '0'");
             $migration->addKey($table, 'entities_id');
             $migration->addPostQuery(
-                "UPDATE `$table` AS export
-                 INNER JOIN `glpi_users` AS export_user ON export_user.id = export.users_id
-                 SET export.entities_id = export_user.entities_id",
+                $DB->buildUpdate(
+                    $table,
+                    ['entities_id' => new QueryExpression($DB->quoteName('glpi_users') . '.' . $DB->quoteName('entities_id'))],
+                    ['entities_id' => 0],
+                    ['INNER JOIN' => ['glpi_users' => ['FKEY' => [$table => 'users_id', 'glpi_users' => 'id']]]],
+                ),
             );
         }
 

--- a/inc/export.class.php
+++ b/inc/export.class.php
@@ -201,15 +201,15 @@ class PluginUseditemsexportExport extends CommonDBTM
 
         $entity = new Entity();
         $entity->getFromDB($_SESSION['glpiactive_entity']);
-        $entity_address = '<h3>' . $entity->fields['name'] . '</h3><br />';
-        $entity_address .= $entity->fields['address'] . '<br />';
-        $entity_address .= $entity->fields['postcode'] . ' - ' . $entity->fields['town'] . '<br />';
-        $entity_address .= $entity->fields['country'] . '<br />';
+        $entity_address = '<h3>' . htmlspecialchars($entity->fields['name']) . '</h3><br />';
+        $entity_address .= htmlspecialchars($entity->fields['address']) . '<br />';
+        $entity_address .= htmlspecialchars($entity->fields['postcode']) . ' - ' . htmlspecialchars($entity->fields['town']) . '<br />';
+        $entity_address .= htmlspecialchars($entity->fields['country']) . '<br />';
         if (isset($entity->fields['email'])) {
-            $entity_address .= __s('Email') . ' : ' . $entity->fields['email'] . '<br />';
+            $entity_address .= __s('Email') . ' : ' . htmlspecialchars($entity->fields['email']) . '<br />';
         }
         if (isset($entity->fields['phonenumber'])) {
-            $entity_address .= __s('Phone') . ' : ' . $entity->fields['phonenumber'] . '<br />';
+            $entity_address .= __s('Phone') . ' : ' . htmlspecialchars($entity->fields['phonenumber']) . '<br />';
         }
 
         $User = new User();
@@ -261,6 +261,7 @@ class PluginUseditemsexportExport extends CommonDBTM
         $export = new self();
         $export->add([
             'users_id'     => $users_id,
+            'entities_id'  => $User->fields['entities_id'],
             'date_mod'     => date('Y-m-d H:i:s'),
             'num'          => $num,
             'refnumber'    => $refnumber,
@@ -461,14 +462,25 @@ class PluginUseditemsexportExport extends CommonDBTM
             $query = "CREATE TABLE IF NOT EXISTS `$table` (
                   `id` INT {$default_key_sign} NOT NULL AUTO_INCREMENT,
                   `users_id` INT {$default_key_sign} NOT NULL DEFAULT '0',
+                  `entities_id` INT {$default_key_sign} NOT NULL DEFAULT '0',
                   `date_mod` TIMESTAMP NULL DEFAULT NULL,
                   `num` SMALLINT NOT NULL DEFAULT 0,
                   `refnumber` VARCHAR(9) NOT NULL DEFAULT '0000-0000',
                   `authors_id` INT {$default_key_sign} NOT NULL DEFAULT '0',
                   `documents_id` INT {$default_key_sign} NOT NULL DEFAULT '0',
-               PRIMARY KEY  (`id`)
+               PRIMARY KEY  (`id`),
+               KEY `entities_id` (`entities_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
             $DB->doQuery($query);
+        } elseif (!$DB->fieldExists($table, 'entities_id', false)) {
+            $migration->displayMessage("Adding entities_id to $table");
+            $migration->addField($table, 'entities_id', "INT {$default_key_sign} NOT NULL DEFAULT '0'");
+            $migration->addKey($table, 'entities_id');
+            $migration->addPostQuery(
+                "UPDATE `$table` AS export
+                 INNER JOIN `glpi_users` AS export_user ON export_user.id = export.users_id
+                 SET export.entities_id = export_user.entities_id",
+            );
         }
 
         return true;
@@ -485,6 +497,13 @@ class PluginUseditemsexportExport extends CommonDBTM
         global $DB;
 
         $table = getTableForItemType(self::class);
+
+        if ($DB->tableExists($table)) {
+            $doc = new Document();
+            foreach ($DB->request(['FROM' => $table]) as $row) {
+                $doc->delete(['id' => $row['documents_id']], true);
+            }
+        }
 
         $query = 'DROP TABLE IF EXISTS  `' . $table . '`';
         $DB->doQuery($query);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- The export purge action deleted records by a raw submitted id without checking that the record belonged to the caller's entity.
- Added a per-record entity check before deletion, added an entities_id column to the export table (backfilled for existing records), and populated it when new export records are created.
- The table migration for existing installs now goes through the plugin's Migration helper instead of raw SQL, so it runs consistently with the rest of the install process.

## Screenshots (if appropriate):
