### PR TITLE
Fix: resolve access denied on export generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix "Access Denied" on export generation caused by `User::getEntityID()` always returning -1
+
 ## [2.6.3] - 2026-08-04
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/front/export.form.php
+++ b/front/export.form.php
@@ -40,7 +40,7 @@ $PluginUseditemsexportExport = new PluginUseditemsexportExport();
 if (isset($_REQUEST['generate'])) {
     Session::checkRight('plugin_useditemsexport_export', CREATE);
     $User = new User();
-    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToEntity($User->getEntityID())) {
+    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToEntity($User->fields['entities_id'])) {
         throw new AccessDeniedHttpException();
     }
     if ($PluginUseditemsexportExport::generatePDF($_POST['users_id'])) {

--- a/front/export.form.php
+++ b/front/export.form.php
@@ -39,8 +39,10 @@ $PluginUseditemsexportExport = new PluginUseditemsexportExport();
 
 if (isset($_REQUEST['generate'])) {
     Session::checkRight('plugin_useditemsexport_export', CREATE);
-    $User = new User();
-    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($_POST['users_id'], false))) {
+    if (
+        !(new User())->getFromDB($_POST['users_id'])
+        || !Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($_POST['users_id'], false))
+    ) {
         throw new AccessDeniedHttpException();
     }
     if ($PluginUseditemsexportExport::generatePDF($_POST['users_id'])) {

--- a/front/export.form.php
+++ b/front/export.form.php
@@ -40,7 +40,7 @@ $PluginUseditemsexportExport = new PluginUseditemsexportExport();
 if (isset($_REQUEST['generate'])) {
     Session::checkRight('plugin_useditemsexport_export', CREATE);
     $User = new User();
-    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToEntity($User->fields['entities_id'])) {
+    if (!$User->getFromDB($_POST['users_id']) || !Session::haveAccessToOneOfEntities(Profile_User::getUserEntities($_POST['users_id'], false))) {
         throw new AccessDeniedHttpException();
     }
     if ($PluginUseditemsexportExport::generatePDF($_POST['users_id'])) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #141
- Export generation always failed with "Access Denied", regardless of the user's rights or entity.
- `User::getEntityID()` always returns -1 because GLPI's `User` class marks entity assignment as a preference only, not a real link.
- The entity access check now reads the user's entity directly from `entities_id`, matching how the export record itself stores it.

## Screenshots (if appropriate):
